### PR TITLE
Remove obsolete "--no-safety" flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - [#9](https://github.com/sqlfluff/vscode-sqlfluff/pull/9) adds VS Code "format" capability to run "fix" in SQLFLuff
 - [#10](https://github.com/sqlfluff/vscode-sqlfluff/pull/10) updates README and adds TESTING.md
 - [#16](https://github.com/sqlfluff/vscode-sqlfluff/pull/17) updates README
+- [#26](https://github.com/sqlfluff/vscode-sqlfluff/pull/26) remove obsolete "--no-safety" flag
 
 ## [0.0.4] - 2020-11-16
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ By default the linter will lint on the fly `"sql.linter.run": "onType"` but can 
 
 ### Format file
 
-By default you will be able use SQLFluff fix your file by formatting. Same as calling `sqlfluff fix --force --no-safey <path>`
+By default you will be able use SQLFluff fix your file by formatting. Same as calling `sqlfluff fix --force <path>`
 
 ![plugin configuration](./media/format_config.gif)
 

--- a/src/features/formatter/formattingProvider.ts
+++ b/src/features/formatter/formattingProvider.ts
@@ -26,8 +26,8 @@ export class DocumentFormattingEditProvider {
     if (linterConfiguration.formatterEnabled) {
       let executable = linterConfiguration.executable;
       let tmp = linterConfiguration.bufferArgs;
-      // let args: string[] = ["fix", "--force", "--no-safety", document.fileName];
-      let args: string[] = ["fix", "--force", "--no-safety", "-"];
+      // let args: string[] = ["fix", "--force", document.fileName];
+      let args: string[] = ["fix", "--force", "-"];
       let options = vscode.workspace.rootPath
         ? { cwd: vscode.workspace.rootPath }
         : undefined;


### PR DESCRIPTION
The "--no-safety" flag was removed in latest version of sqlfluff resulting the "format document" action to break, because the flag is invalid.

Removing the flag and rebuilding resolves the issue.