### PR TITLE
UPDATE: Enable linting and formatting for sql-bigquery filetypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 
 - [#33](https://github.com/sqlfluff/vscode-sqlfluff/pull/33) adds basic set of automated tests
+- [](temp) added `sql-bigquery` as filetype, to enable linting and formatting when using addons that registery this filetype
 
 ## [0.0.5] - 2021-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [Unreleased]
 
 - [#33](https://github.com/sqlfluff/vscode-sqlfluff/pull/33) adds basic set of automated tests
-- [](temp) added `sql-bigquery` as filetype, to enable linting and formatting when using addons that registery this filetype
+- [#42](https://github.com/sqlfluff/vscode-sqlfluff/pull/42) added `sql-bigquery` as filetype, to enable linting and formatting when using addons that registery this filetype
 
 ## [0.0.5] - 2021-06-16
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "vscode-sqlfluff",
 			"version": "0.0.5",
 			"license": "SEE LICENSE IN LICENSE",
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"bugs": {
 		"url": "https://github.com/dorzey/vscode-sqlfluff/issues"
 	},
-	"version": "0.0.5",
+	"version": "0.0.5b",
 	"engines": {
 		"vscode": "^1.46.0"
 	},
@@ -23,7 +23,8 @@
 	"keywords": [
 		"dbt",
 		"sql",
-		"jinja-sql"
+		"jinja-sql",
+		"sql-bigquery"
 	],
 	"activationEvents": [
 		"onLanguage:sql",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 	],
 	"activationEvents": [
 		"onLanguage:sql",
-		"onLanguage:jinja-sql"
+		"onLanguage:jinja-sql",
+		"onLanguage:sql-bigquery"
 	],
 	"main": "./out/extension.js",
 	"contributes": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"bugs": {
 		"url": "https://github.com/dorzey/vscode-sqlfluff/issues"
 	},
-	"version": "0.0.5b",
+	"version": "0.0.5",
 	"engines": {
 		"vscode": "^1.46.0"
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ export const activate = (context: vscode.ExtensionContext) => {
 
 	vscode.languages.registerDocumentFormattingEditProvider('jinja-sql', new SqlFLuffDocumentFormattingEditProvider().activate());
 	vscode.languages.registerDocumentFormattingEditProvider('sql', new SqlFLuffDocumentFormattingEditProvider().activate());
+	vscode.languages.registerDocumentFormattingEditProvider('sql-bigquery', new SqlFLuffDocumentFormattingEditProvider().activate());
 };
 
 export const deactivate: any = () => {};


### PR DESCRIPTION
Hello everyone, I started using this extension which provides some extra features to bigquery sql files: 
[SQL (BigQuery)](https://marketplace.visualstudio.com/items?itemName=shinichi-takii.sql-bigquery)

This addon registers a new filetype called `sql-bigquery`. I have added  the filetype to the linter and formatter.