### PR TITLE
Issue-36 : More robust JSON escaping normalization 

### DIFF
--- a/src/features/helper/utilities.ts
+++ b/src/features/helper/utilities.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 
 export function normalize(path: string): string {
-  return path.replace(/\\+/g, "/");
+  return path.replace(/\\{2,}/g, "/");
 }
 
 export class Utilities {


### PR DESCRIPTION
The previous regex was too generous, and messages with single `\` for escaping, say, `"`  were also turned into the wrong `/` .