### PR TITLE
feat: add support for the 'postgres' language mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,14 @@
     "dbt",
     "sql",
     "sql-bigquery",
-    "jinja-sql"
+    "jinja-sql",
+    "postgres"
   ],
   "activationEvents": [
     "onLanguage:sql",
     "onLanguage:sql-bigquery",
-    "onLanguage:jinja-sql"
+    "onLanguage:jinja-sql",
+    "onLanguage:postgres"
   ],
   "main": "./out/src/extension.js",
   "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ export const activate = (context: vscode.ExtensionContext) => {
   vscode.languages.registerDocumentFormattingEditProvider("sql", new FormattingEditProvider().activate());
   vscode.languages.registerDocumentFormattingEditProvider("sql-bigquery", new FormattingEditProvider().activate());
   vscode.languages.registerDocumentFormattingEditProvider("jinja-sql", new FormattingEditProvider().activate());
+  vscode.languages.registerDocumentFormattingEditProvider("postgres", new FormattingEditProvider().activate());
 
   if (!Configuration.osmosisEnabled()) {
     context.subscriptions.push(
@@ -28,6 +29,9 @@ export const activate = (context: vscode.ExtensionContext) => {
       }),
       vscode.languages.registerCodeActionsProvider("jinja-sql", new QuickFixProvider(), {
         providedCodeActionKinds: QuickFixProvider.providedCodeActionKind
+      }),
+      vscode.languages.registerCodeActionsProvider("postgres", new QuickFixProvider(), {
+        providedCodeActionKinds: QuickFixProvider.providedCodeActionKind
       })
     );
   }
@@ -36,6 +40,7 @@ export const activate = (context: vscode.ExtensionContext) => {
     vscode.languages.registerHoverProvider("sql", new HoverProvider()),
     vscode.languages.registerHoverProvider("sql-bigquery", new HoverProvider()),
     vscode.languages.registerHoverProvider("jinja-sql", new HoverProvider()),
+    vscode.languages.registerHoverProvider("postgres", new HoverProvider()),
   );
 
   context.subscriptions.push(vscode.commands.registerCommand(EXCLUDE_RULE, ExcludeRules.toggleRule));

--- a/src/features/helper/configuration.ts
+++ b/src/features/helper/configuration.ts
@@ -8,8 +8,8 @@ import RunTrigger from "./types/runTrigger";
 import Variables from "./types/variables";
 import Utilities from "./utilities";
 
-export const filePattern = "**/*.{sql,sql-bigquery,jinja-sql}";
-export const fileRegex = /^.*\.(sql|sql-bigquery|jinja-sql)$/;
+export const filePattern = "**/*.{sql,sql-bigquery,jinja-sql,postgres}";
+export const fileRegex = /^.*\.(sql|sql-bigquery|jinja-sql|postgres)$/;
 
 export default class Configuration {
   /** Initialize the configuration options that require a reload upon change. */

--- a/src/features/linter.ts
+++ b/src/features/linter.ts
@@ -12,7 +12,7 @@ import Linter from "./providers/linter/types/linter";
 import Violation from "./providers/linter/types/violation";
 
 export default class LinterProvider implements Linter {
-  public languageId = ["sql", "jinja-sql", "sql-bigquery"];
+  public languageId = ["sql", "jinja-sql", "sql-bigquery", "postgres"];
 
   public activate(subscriptions: Disposable[]): LintingProvider {
     const provider = new LintingProvider(this);


### PR DESCRIPTION
This way, we can use the "vscode-sqlfluff" plug-in together with postgresql-specific extensions. E.g., the [plpgsql-lsp](https://github.com/UniqueVision/plpgsql-lsp) extension that's hardcoded to work with the "postgres" language mode.

I already built this locally and verified that it works together with the plpgsql-lsp extension.

Let me know what you think.