### PR TITLE
Change URL for sqlfluff rules documantation

### DIFF
--- a/src/features/commands/showDocumentation.ts
+++ b/src/features/commands/showDocumentation.ts
@@ -4,7 +4,7 @@ export const VIEW_DOCUMENTATION = "sqlfluff.quickfix.viewDocumentation";
 
 export class Documentation {
   static showDocumentation(rule: string) {
-    const path = `https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.Rule_${rule}`;
+    const path = `https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_${rule}`;
 
     return vscode.env.openExternal(vscode.Uri.parse(path));
   }


### PR DESCRIPTION
The current rules documentation URL appears to have changed and has been corrected.

- Before
  - <https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.Rule_AL01>
- After (Looks like `sphinx` has been added`sphinx`)
  - <https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_AL01>

