### PR TITLE
Update rules link again for new rule docs

### DIFF
--- a/src/features/commands/showDocumentation.ts
+++ b/src/features/commands/showDocumentation.ts
@@ -4,7 +4,7 @@ export const VIEW_DOCUMENTATION = "sqlfluff.quickfix.viewDocumentation";
 
 export class Documentation {
   static showDocumentation(rule: string) {
-    const path = `https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_${rule}`;
+    const path = `https://docs.sqlfluff.com/en/stable/rules/{rule}.html`;
 
     return vscode.env.openExternal(vscode.Uri.parse(path));
   }


### PR DESCRIPTION
This shouldn't be merged yet, but is the update we'll need to this link again when this change gets released: https://github.com/sqlfluff/sqlfluff/pull/4695

The old link will still "work" (i.e. it won't be a broken link), but it will stop pointing to the right point on the page. I've added some more permanent redirect stubs so we can support more consistent links even if we change the format again in the future.