### PR TITLE
Allow extension activation on snowflake-sql language.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "onLanguage:sql",
     "onLanguage:sql-bigquery",
     "onLanguage:jinja-sql",
-    "onLanguage:postgres"
+    "onLanguage:postgres",
+    "onLanguage:snowflake-sql"
   ],
   "main": "./out/src/extension.js",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "sql",
     "sql-bigquery",
     "jinja-sql",
-    "postgres"
+    "postgres",
+    "snowflake-sql"
   ],
   "activationEvents": [
     "onLanguage:sql",


### PR DESCRIPTION
## What
Allow extension activation on `snowflake-sql` language.

## Why
In [feature: Added snowflake-sql support https://github.com/sqlfluff/vscode-sqlfluff/pull/85](https://github.com/sqlfluff/vscode-sqlfluff/pull/85) this change in `package.json` was missing.

As a reference see [feat: add support for the 'postgres' language mode](https://github.com/sqlfluff/vscode-sqlfluff/commit/9659528b2ff162ff9da5e727262adcfc7722eeb3).

Without this, if you have the [VSCode Snowflake extension](https://marketplace.visualstudio.com/items?itemName=snowflake.snowflake-vsc) installed which makes `.sql` files to use **Snowflake SQL** (`snowflake-sql`) language mode, this extension is not activated (so it can't be used to validate or format `.sql` files).