### PR TITLE
feat: support fileWorkspaceFolder

### DIFF
--- a/src/features/helper/configuration.ts
+++ b/src/features/helper/configuration.ts
@@ -322,6 +322,9 @@ export default class Configuration {
       // - the path of the folder opened in VS Code
       workspaceFolder: rootPath,
 
+      // - the current opened file's workspace folder
+      fileWorkspaceFolder: (editor) ? vscode.workspace.getWorkspaceFolder(editor?.document.uri)?.uri.fsPath : undefined,
+
       // - the last portion of the path of the folder opened in VS Code
       workspaceFolderBasename: rootPath ? path.basename(rootPath) : undefined,
 
@@ -329,7 +332,7 @@ export default class Configuration {
       file: fileName,
 
       // - the current opened file relative to workspaceFolder
-      relativeFile: (vscode.window.activeTextEditor && rootPath && fileName) ? Utilities.normalizePath(path.relative(
+      relativeFile: (editor && rootPath && fileName) ? Utilities.normalizePath(path.relative(
         rootPath,
         fileName
       )) : undefined,

--- a/src/features/helper/types/variables.ts
+++ b/src/features/helper/types/variables.ts
@@ -1,4 +1,5 @@
 type Variables = {
+  fileWorkspaceFolder?: string;
   workspaceFolder?: string;
   workspaceFolderBasename?: string;
   file?: string;


### PR DESCRIPTION
This PR allows to define configuration path using the [`${fileWorkspaceFolder}` predefined variable](https://code.visualstudio.com/docs/editor/variables-reference#_predefined-variables).

This is useful when a workspace contains multiple folders as `${workspaceFolder}` only works for the first folder: https://github.com/sqlfluff/vscode-sqlfluff/blob/v2.2.9/src/features/helper/configuration.ts#L315
