### PR TITLE
Change file paths to use an uppercase drive letter when normalized

### DIFF
--- a/src/features/helper/utilities.ts
+++ b/src/features/helper/utilities.ts
@@ -36,6 +36,9 @@ export default class Utilities {
       return path;
     }
 
+    // Capitalize drive letter
+    path = path.replace(/^[A-Za-z]:/, match => match.toUpperCase());
+
     if (allowEscapes) {
       return path.replace(/\\{2,}/g, "/");
     }


### PR DESCRIPTION
When using the extension to lint, it would neglect to use the `.sqlfluffignore` file in the root of my project. According to the [SQLFluff Docs](https://docs.sqlfluff.com/en/stable/configuration.html#id2), this is where the file should be placed.

I found that the issue would be resolved if I set the `sqlfluff.workingDirectory` using a capital C - `C:\dev\MyProject`. If I used a lowercase c - `c:\dev\MyProject` -  it would not work. While debugging, I noticed that omitting the `sqlfluff.workingDirectory` or using a variable (such as `${workspaceFolder}`) would result in a lowercase c being used as the drive. This aligns with the [VS Code API Docs](https://code.visualstudio.com/api/references/vscode-api) for `fspath`. It always returns a lowercase drive letter.