### PR TITLE
CI: Update GitHub actions to supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,22 +17,24 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 20.x
       - run: npm install
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Install sqlfluff
         run: pip install sqlfluff
-      # - name: Run tests
-      #   uses: GabrielBB/xvfb-action@v1.2
-      #   with:
-      #     run: npm test
+      - name: Run Tests (Linux)
+        run: xvfb-run -a npm test
+        if: runner.os == 'Linux'
+      - name: Run Tests (Non-Linux)
+        run: npm test
+        if: runner.os != 'Linux'
       - name: Publish
         if: success() && startsWith(github.ref, 'refs/tags/') && matrix.os == 'ubuntu-latest'
         run: npm run deploy

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v2

--- a/package.json
+++ b/package.json
@@ -450,6 +450,6 @@
     "typescript": "^5.1.6",
     "@vscode/vsce": "^2.15.0",
     "@vscode/dts": "^0.4.0",
-    "@vscode/test-electron": "^1.6.1"
+    "@vscode/test-electron": "^2.3.9"
   }
 }


### PR DESCRIPTION
This PR should fix some issues with the CI process:
- Fix the issue with test cases unable to download VSCode.
- Remove the depreciation warnings for the older Node versions.