### PR TITLE
Add support for --stdin-filename for nested config

### DIFF
--- a/src/features/providers/linter/lint.ts
+++ b/src/features/providers/linter/lint.ts
@@ -112,7 +112,7 @@ export default class LintingProvider {
     const workspaceFolder = vscode.workspace.workspaceFolders ? vscode.workspace.workspaceFolders[0].uri.fsPath : undefined;
     const rootPath = workspaceFolder ? Utilities.normalizePath(workspaceFolder) : undefined;
     const workingDirectory = workspacePath ?? Configuration.workingDirectory(rootPath);
-    const filePath = document ? Utilities.normalizePath(document.fileName) : workingDirectory;
+    const filePath = document && !document.isUntitled ? Utilities.normalizePath(document.fileName) : workingDirectory;
 
     if (!filePath) {
       Utilities.outputChannel.appendLine("ERROR: File path not found.");


### PR DESCRIPTION
PR sqlfluff/sqlfluff#5805 added pulling in configurations from a filename when stdin was used as a source. This will allow nested configurations to be pulled in when using the content of the existing, but dirty file.

- Added executable version checking to dynamically enable this feature on supported versions of sqlfluff (the release after 3.0.5).
- Added version checking for differences between 2.3.5 and 3.0.0.
- fixes #51 