### PR TITLE
Prevent "Specified path does not exist" error for empty untitled files

### DIFF
--- a/src/features/providers/formatter/format.ts
+++ b/src/features/providers/formatter/format.ts
@@ -26,6 +26,10 @@ export class FormattingProvider implements vscode.DocumentFormattingEditProvider
       return [];
     }
 
+    if (document && document.isUntitled && document.getText() === "") {
+      return [];
+    }
+
     Utilities.appendHyphenatedLine();
     Utilities.outputChannel.appendLine(`Format triggered for ${filePath}`);
 

--- a/src/features/providers/linter/lint.ts
+++ b/src/features/providers/linter/lint.ts
@@ -141,6 +141,10 @@ export default class LintingProvider {
       return;
     }
 
+    if (document && document.isUntitled && document.getText() === "") {
+      return;
+    }
+
     const args: string[] = [...Configuration.lintFileArguments()];
     const options: CommandOptions = { filePath: filePath };
 


### PR DESCRIPTION
I use the vscode-sqlfluff extension with Azure Data Studio. I recently moved to a new computer and after getting ADS set back up, I noticed that the extension was throwing an error saying "User Error: Specified path does not exist. Check it/they exist(s): ." whenver I open a new file (via File > New Query or right clicking on a database and clicking New Query).

![image](https://github.com/user-attachments/assets/a2bbe612-926b-43d5-a0e8-deb3bc5fb8bd)

The error only happens when the file first opens and is empty. As soon as the file has text/sql in it, the extension works and lints the file as expected. Nothing changed with my local extension config when I moved my files to the new computer (I did download the latest version of SqlFluff so it's possible I have newer version of that, but I can't remember what version I had installed on my old PC), so I'm not sure what would cause this error to start occuring all of the sudden.

Since it's not really necessary to lint an empty file, I thought an easy fix would be to skip linting when you're in an untitled file that's empty. I tested locally with this change and everything worked as expected. I also had a coworker who was experiencing the error do some testing and they reported no longer seeing the error with this change.