### PR TITLE
Update to rule permalinks

### DIFF
--- a/src/features/providers/linter/actions/hover.ts
+++ b/src/features/providers/linter/actions/hover.ts
@@ -27,7 +27,10 @@ export default class HoverProvider implements vscode.HoverProvider {
   }
 
   private createHover(diagnostic: vscode.Diagnostic): vscode.Hover {
-    const path = `https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.rules.sphinx.Rule_${diagnostic.code}`;
+    // Link to the rule permalinks so that if the rule docs move in the future that
+    // we don't have to update the links here. We rely on the docs internally redirecting
+    // us to the appropriate location.
+    const path = `https://docs.sqlfluff.com/en/stable/perma/rule/${diagnostic.code}.html`;
     const markdownString = new vscode.MarkdownString();
 
     markdownString.appendMarkdown(`[View Documentation](${path}) for Rule ${diagnostic.code}.\n`);


### PR DESCRIPTION
This is necessary because of https://github.com/sqlfluff/sqlfluff/pull/6052 (which broke the current links) and relies on https://github.com/sqlfluff/sqlfluff/pull/6066 (to enable rule permalinks).

We should probably do a coordinated release of both the plugin and sqlfluff so these go live at roughly the same moment. I'm likely to do a SQLFluff release later this week so that might be a good moment.

