### PR TITLE
Update sqlfluff repo link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Hosted VS Code, dbt-core, SqlFluff, and Airflow, find out more at [Datacoves.com
 
 ![.github/workflows/ci.yml](https://github.com/dorzey/vscode-sqlfluff/workflows/.github/workflows/ci.yml/badge.svg)
 
-A linter and auto-formatter for [SQLFluff](https://github.com/alanmcruickshank/sqlfluff), a popular linting tool for SQL and dbt.
+A linter and auto-formatter for [SQLFluff](https://github.com/sqlfluff/sqlfluff), a popular linting tool for SQL and dbt.
 
 ![linter in action](./media/linter_in_action.gif)
 


### PR DESCRIPTION
This pull request updates the README to point to the correct SQLFluff repository.

Changed the SQLFluff link from https://github.com/alanmcruickshank/sqlfluff to https://github.com/sqlfluff/sqlfluff

- fixes #182 