### PR TITLE
Update package manifest to new publisher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "sqlfluff" extension will be documented in this file.
 
+## [4.0.0] - 2026-01-13
+
+- Changed extension publisher from `dorzey` to `sqlfluff`. [Issue](https://github.com/sqlfluff/vscode-sqlfluff/issues/185)
+
 ## [3.7.0] - 2025-12-28
 
 - Fix bug with code actions. [Issue](https://github.com/sqlfluff/vscode-sqlfluff/issues/184)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Hosted VS Code, dbt-core, SqlFluff, and Airflow, find out more at [Datacoves.com
 
 # vscode-sqlfluff
 
-![.github/workflows/ci.yml](https://github.com/dorzey/vscode-sqlfluff/workflows/.github/workflows/ci.yml/badge.svg)
+![.github/workflows/ci.yml](https://github.com/sqlfluff/vscode-sqlfluff/workflows/.github/workflows/ci.yml/badge.svg)
 
 A linter and auto-formatter for [SQLFluff](https://github.com/sqlfluff/sqlfluff), a popular linting tool for SQL and dbt.
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "vscode-sqlfluff",
   "displayName": "sqlfluff",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "description": "A linter and auto-formatter for SQLfluff, a popular linting tool for SQL and dbt.",
-  "publisher": "dorzey",
+  "publisher": "sqlfluff",
   "icon": "images/icon.png",
   "engines": {
     "vscode": "^1.63.0"

--- a/test/suite/helper.ts
+++ b/test/suite/helper.ts
@@ -5,7 +5,7 @@ export const SLEEP_TIME = 2000;
 
 export const activate = async (documentUri: vscode.Uri): Promise<vscode.TextDocument | undefined> => {
   // The extensionId is `publisher.name` from package.json
-  const extension = vscode.extensions.getExtension("dorzey.vscode-sqlfluff");
+  const extension = vscode.extensions.getExtension("sqlfluff.vscode-sqlfluff");
   assert.notStrictEqual(extension, undefined);
   await extension?.activate();
   try {


### PR DESCRIPTION
This updates the manifest to use the publisher `sqlfluff` from `dorzey` as the vscode marketplace has been updated to the new `sqlfluff` publisher.

Bumping the version to 4.0.0 as I'm unsure if the publisher has some impact to the packaging system.