### PR TITLE
Fix empty-string and 0 env var values

### DIFF
--- a/src/features/helper/configuration.ts
+++ b/src/features/helper/configuration.ts
@@ -52,7 +52,7 @@ export default class Configuration {
     for (const variable of deprecatedEnvironmentVariables) {
       const key = variable?.key ?? undefined;
       const value = variable?.value ?? undefined;
-      if (key && value) {
+      if (key && value !== undefined) {
         environment[key] = value;
       }
     }
@@ -65,7 +65,7 @@ export default class Configuration {
     for (const variable of environmentVariables) {
       const key = variable?.key ?? undefined;
       const value = variable?.value ?? undefined;
-      if (key && value) {
+      if (key && value !== undefined) {
         environment[key] = value;
       }
     }


### PR DESCRIPTION
I have a bash script that regularly updates the env vars depending on which dbt environment I want to point to.

I noticed a pattern that sqlfluff.env.environmentVariables are not working when, at the opening of VSCode, a variable value is an empty string but after setting it up and removing it again it works...

Reading the code quickly, I'm sure the `if (key && value)` was wrong because "" and 0 are falsy but valid values and I'm thus 80% sure that this fix should fix my issue but to be totally honest, I didn't take the time to test it by setting it up in my VSCode... Anyway since it's a meaningful code change, I would still argue that it makes sense to merge this :) (and I will just pray that it fixes my issues without me spending more time on debugging and testing :) )

Comment about the fix:
Another equally valid fix is to just do if (key) instead of if (key && value !== undefined) but I'm not too sure how it would be handled/rendered down the line in dbt (and same for null => Unsure how it would be rendered in dbt but the value is also transformed to undefined in the line just above the one I modified so !== null check is not necessary). So TL;DR: I think if (key && value !== undefined) is a decent solution (but obviously feel free to change it if I'm wrong).


Thank you for this extension in general, it's great! <3